### PR TITLE
Make grey bar selection more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ui-customization
-Minor customizations for the Odoo UI
+Minor customizations for the UI of Odoo Community v17.
+
+## UI Changes
+
+### 1. Calendar View Grey Bars (Leave/My Time/Dashboard)
+
+Got rid of grey bar that was overlaying calendar view.

--- a/static/src/scss/custom_styles.scss
+++ b/static/src/scss/custom_styles.scss
@@ -1,9 +1,7 @@
-/* Override the specific Odoo core style for thead background */
-.o_web_client thead {
+/* Fix grey overlay in calendar view of Leave/My Time/Dashboard
+Override the Odoo core style for thead background.
+Use class `.fc-dayGrid-view` to be more specific.
+*/
+.fc-dayGrid-view thead {
     background-color: transparent !important;
 }
-
-/* Or a more specific selector if needed, as discussed before: */
-/* .o_time_off_calendar_dashboard thead {
-    background-color: transparent !important;
-} */


### PR DESCRIPTION
Replace `.o_web_client thead` with `.fc-dayGrid-view thead`

Before Fix:
<img width="1285" alt="Screenshot 2025-06-27 at 00 15 22" src="https://github.com/user-attachments/assets/87ab8dc0-c928-4821-aae5-f267e5944a17" />

With general selector:
<img width="1006" alt="Screenshot 2025-06-27 at 00 17 26" src="https://github.com/user-attachments/assets/aa73be20-7e53-4509-81db-c4dcb846ca4c" />

With specific selector:
<img width="957" alt="Screenshot 2025-06-27 at 01 05 07" src="https://github.com/user-attachments/assets/57b4b754-876b-4838-92d7-bbe1ccde9f43" />

